### PR TITLE
external name: use identifierfromprovider as provider-wide default

### DIFF
--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -18,6 +18,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 
 	p.AddResourceConfigurator("google_compute_managed_ssl_certificate", func(r *config.Resource) {
 		r.Kind = "ManagedSSLCertificate"
+		r.ExternalName = config.NameAsIdentifier
 		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
 		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			project, err := common.GetField(providerConfig, common.KeyProject)
@@ -30,6 +31,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 	})
 
 	p.AddResourceConfigurator("google_compute_subnetwork", func(r *config.Resource) {
+		r.ExternalName = config.NameAsIdentifier
 		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
 		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			project, err := common.GetField(providerConfig, common.KeyProject)
@@ -49,6 +51,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 	})
 
 	p.AddResourceConfigurator("google_compute_address", func(r *config.Resource) {
+		r.ExternalName = config.NameAsIdentifier
 		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
 		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			project, err := common.GetField(providerConfig, common.KeyProject)
@@ -70,6 +73,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 	})
 
 	p.AddResourceConfigurator("google_compute_firewall", func(r *config.Resource) {
+		r.ExternalName = config.NameAsIdentifier
 		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
 		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			project, err := common.GetField(providerConfig, common.KeyProject)
@@ -85,6 +89,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 	})
 
 	p.AddResourceConfigurator("google_compute_router", func(r *config.Resource) {
+		r.ExternalName = config.NameAsIdentifier
 		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
 		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			project, err := common.GetField(providerConfig, common.KeyProject)
@@ -104,6 +109,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 	})
 
 	p.AddResourceConfigurator("google_compute_router_nat", func(r *config.Resource) {
+		r.ExternalName = config.NameAsIdentifier
 		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
 		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			project, err := common.GetField(providerConfig, common.KeyProject)
@@ -135,6 +141,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 		// elements configured as nil, defaulting to map[string]string:
 		r.TerraformResource.Schema["metadata"].Elem = schema.TypeString
 
+		r.ExternalName = config.NameAsIdentifier
 		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
 		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			project, err := common.GetField(providerConfig, common.KeyProject)
@@ -155,6 +162,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 			Schema["initialize_params"].Elem.(*schema.Resource).
 			Schema["labels"].Elem = schema.TypeString
 
+		r.ExternalName = config.NameAsIdentifier
 		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
 		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			project, err := common.GetField(providerConfig, common.KeyProject)
@@ -189,6 +197,7 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 			Schema["labels"].Elem = schema.TypeString
 		r.TerraformResource.Schema["metadata"].Elem = schema.TypeString
 
+		r.ExternalName = config.NameAsIdentifier
 		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
 		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			project, err := common.GetField(providerConfig, common.KeyProject)
@@ -210,5 +219,15 @@ func Configure(p *config.Provider) { //nolint: gocyclo
 		}
 
 		r.UseAsync = true
+	})
+
+	p.AddResourceConfigurator("google_compute_network", func(r *config.Resource) {
+		r.ExternalName = config.NameAsIdentifier
+		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
+		// projects/{{project}}/global/networks/{{name}}
+		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
+			project, err := common.GetField(providerConfig, common.KeyProject)
+			return fmt.Sprintf("projects/%s/global/networks/%s", project, externalName), err
+		}
 	})
 }

--- a/config/overrides.go
+++ b/config/overrides.go
@@ -3,8 +3,9 @@ package config
 import (
 	"strings"
 
-	tjconfig "github.com/crossplane-contrib/terrajet/pkg/config"
 	"github.com/iancoleman/strcase"
+
+	tjconfig "github.com/crossplane-contrib/terrajet/pkg/config"
 
 	"github.com/crossplane-contrib/provider-jet-gcp/config/accessapproval"
 	"github.com/crossplane-contrib/provider-jet-gcp/config/cloudplatform"
@@ -50,5 +51,11 @@ func groupOverrides() tjconfig.ResourceOption { //nolint: gocyclo
 			r.ShortGroup = words[1] + words[2]
 			r.Kind = strcase.ToCamel(strings.Join(words[3:], "_"))
 		}
+	}
+}
+
+func externalNameConfig() tjconfig.ResourceOption {
+	return func(r *tjconfig.Resource) {
+		r.ExternalName = tjconfig.IdentifierFromProvider
 	}
 }

--- a/config/provider.go
+++ b/config/provider.go
@@ -48,7 +48,10 @@ var includeList = []string{
 func GetProvider() *tjconfig.Provider {
 	resourceMap := tf.Provider().ResourcesMap
 	pc := tjconfig.NewProvider(resourceMap, resourcePrefix, modulePath,
-		tjconfig.WithDefaultResourceFn(DefaultResource(groupOverrides())),
+		tjconfig.WithDefaultResourceFn(DefaultResource(
+			groupOverrides(),
+			externalNameConfig(),
+		)),
 		tjconfig.WithRootGroup("gcp.jet.crossplane.io"),
 		tjconfig.WithShortName("gcpjet"),
 		// Comment out the following line to generate all resources.

--- a/config/storage/config.go
+++ b/config/storage/config.go
@@ -1,7 +1,12 @@
 package storage
 
 import (
+	"context"
+	"path/filepath"
+
 	"github.com/crossplane-contrib/terrajet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-jet-gcp/config/common"
 )
 
 // Configure configures individual resources by adding custom
@@ -16,5 +21,10 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("google_storage_bucket", func(r *config.Resource) {
 		r.ExternalName = config.NameAsIdentifier
+		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
+		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
+			project, err := common.GetField(providerConfig, common.KeyProject)
+			return filepath.Join(project, externalName), err
+		}
 	})
 }


### PR DESCRIPTION
### Description of your changes

Otherwise the default `NameAsIdentifier` won't work since IDs are almost never name in GCP provider.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
