### PR TITLE
Configure GKE Cluster to return kubeconfig in connection secret

### DIFF
--- a/config/common/config.go
+++ b/config/common/config.go
@@ -17,8 +17,6 @@ const (
 	// SelfPackagePath is the golang path for this package.
 	SelfPackagePath = "github.com/crossplane-contrib/provider-jet-gcp/config/common"
 
-	errFmtCannotGetFieldAsString = "cannot get the %q field as string"
-
 	// ExtractResourceIDFuncPath holds the GCP resource ID extractor func name
 	ExtractResourceIDFuncPath = "github.com/crossplane-contrib/provider-jet-gcp/config/common.ExtractResourceID()"
 )
@@ -58,12 +56,8 @@ func GetNameFromFullyQualifiedID(tfstate map[string]interface{}) (string, error)
 
 // GetField returns the value of field as a string in a map[string]interface{},
 //  fails properly otherwise.
-func GetField(mapping map[string]interface{}, field string) (string, error) {
-	f, ok := mapping[field].(string)
-	if !ok {
-		return "", errors.Errorf(errFmtCannotGetFieldAsString, f)
-	}
-	return f, nil
+func GetField(from map[string]interface{}, path string) (string, error) {
+	return fieldpath.Pave(from).GetString(path)
 }
 
 // ExtractResourceID extracts the value of `spec.atProvider.id`

--- a/examples/container/cluster.yaml
+++ b/examples/container/cluster.yaml
@@ -1,0 +1,12 @@
+apiVersion: container.gcp.jet.crossplane.io/v1alpha1
+kind: Cluster
+metadata:
+  name: example-gke-cluster
+spec:
+  forProvider:
+    initialNodeCount: 1
+    location: us-central1
+    removeDefaultNodePool: false
+  writeConnectionSecretToRef:
+    name: example-gke-cluster-secret
+    namespace: crossplane-system

--- a/examples/container/nodepool.yaml
+++ b/examples/container/nodepool.yaml
@@ -1,7 +1,7 @@
 apiVersion: container.gcp.jet.crossplane.io/v1alpha1
 kind: NodePool
 metadata:
-  name: my-node-pool
+  name: example-node-pool
 spec:
   forProvider:
     nodeConfig:
@@ -11,4 +11,4 @@ spec:
         preemptible: true
     nodeCount: 1
     clusterRef:
-      name: my-gke-cluster
+      name: example-gke-cluster

--- a/examples/kubernetes/cluster.yaml
+++ b/examples/kubernetes/cluster.yaml
@@ -1,9 +1,0 @@
-apiVersion: container.gcp.jet.crossplane.io/v1alpha1
-kind: Cluster
-metadata:
-  name: my-gke-cluster
-spec:
-  forProvider:
-    initialNodeCount: 1
-    location: us-central1
-    removeDefaultNodePool: true


### PR DESCRIPTION
### Description of your changes

This PR configures GKE Cluster resources such that it returns a `kubeconfig` in connection details secret.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Create a GKE cluster and check connection secret.

[contribution process]: https://git.io/fj2m9
