### PR TITLE
Workaround for bucket bug: add timeout annotation

### DIFF
--- a/examples/storage/bucket.yaml
+++ b/examples/storage/bucket.yaml
@@ -1,10 +1,17 @@
-apiVersion: storage.gcp.jet.crossplane.io/v1alpha1
+apiVersion: storage.gcp.jet.crossplane.io/v1alpha2
 kind: Bucket
 metadata:
   name: example
   annotations:
-    # Note that this will be the actual bucket name so it has to be globally unique/available.
-    crossplane.io/external-name: crossplane-example-bucket
+    # Note that this will be the actual bucket name, so it has to be globally
+    #  unique/available.
+    crossplane.io/external-name: crossplane-example-bucket-0099
+    # This annotation is a workaround for the following bug which sets
+    #  create/read timeouts to 1 min:
+    # "https://github.com/crossplane-contrib/provider-jet-gcp/issues/12
+    # "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0" is the TimeoutKey:
+    #  https://github.com/hashicorp/terraform-plugin-sdk/blob/112e2164c381d80e8ada3170dac9a8a5db01079a/helper/schema/resource_timeout.go#L14
+    terrajet.crossplane.io/provider-meta: '{"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0":{"create":60000000000,"read":60000000000}}'
 spec:
   forProvider:
     location: US


### PR DESCRIPTION
### Description of your changes

This PR is a workaround for #12 which has the same underlying problem as [this issue](https://github.com/hashicorp/terraform-provider-google/issues/10423) that is introduced to Terraform provider starting with version 3.89.0. The change causing the problem is [this one](https://github.com/GoogleCloudPlatform/magic-modules/pull/5288) adding retry's to read, create and update methods of bucket resource. In case of a non existing bucket, e.g. a terraform provisioned bucket removed from cloud console, plan/refresh call simply stuck for 20mins before returning that bucket does not exist.

In case of Terrajet, this is a bit more severe, since it is trying to refresh the resource in the first observe call resulting the behavior described in #12.

This PR introduces a metadata argument to the bucket example which configures it to timeout after 1 mins. This is still a temporary solution and we will followup with another Terraform fix and also consider best way deal with this type of issues in Terrajet. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Create/delete a bucket with the updated example.

[contribution process]: https://git.io/fj2m9
