### PR TITLE
Update google_sql_database_instance config to output connection details

### DIFF
--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -27,43 +27,41 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		// NOTE(@tnthornton) most of the connection details that were exported
 		// to the connection details secret are marked as non-sensitive for tf.
 		// We need to manually construct the secret details for those items.
-		r.Sensitive = config.Sensitive{
-			AdditionalConnectionDetailsFn: func(attr map[string]interface{}) (map[string][]byte, error) {
-				conn := map[string][]byte{}
-				if a, ok := attr["connection_name"].(string); ok {
-					conn["connectionName"] = []byte(a)
-				}
-				if a, ok := attr["private_ip_address"].(string); ok {
-					conn["privateIpAddress"] = []byte(a)
-				}
-				if a, ok := attr["public_ip_address"].(string); ok {
-					conn["publicIpAddress"] = []byte(a)
-				}
-				if a, ok := attr["root_password"].(string); ok {
-					conn["rootPassword"] = []byte(a)
-				}
-				// map
-				if certSlice, ok := attr["server_ca_cert"].([]interface{}); ok {
-					if certattrs, ok := certSlice[0].(map[string]interface{}); ok {
-						if a, ok := certattrs["cert"].(string); ok {
-							conn["cert"] = []byte(a)
-						}
-						if a, ok := certattrs["common_name"].(string); ok {
-							conn["commonName"] = []byte(a)
-						}
-						if a, ok := certattrs["create_time"].(string); ok {
-							conn["createTime"] = []byte(a)
-						}
-						if a, ok := certattrs["expiration_time"].(string); ok {
-							conn["expirationTime"] = []byte(a)
-						}
-						if a, ok := certattrs["sha1_fingerprint"].(string); ok {
-							conn["sha1Fingerprint"] = []byte(a)
-						}
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if a, ok := attr["connection_name"].(string); ok {
+				conn["connectionName"] = []byte(a)
+			}
+			if a, ok := attr["private_ip_address"].(string); ok {
+				conn["privateIpAddress"] = []byte(a)
+			}
+			if a, ok := attr["public_ip_address"].(string); ok {
+				conn["publicIpAddress"] = []byte(a)
+			}
+			if a, ok := attr["root_password"].(string); ok {
+				conn["rootPassword"] = []byte(a)
+			}
+			// map
+			if certSlice, ok := attr["server_ca_cert"].([]interface{}); ok {
+				if certattrs, ok := certSlice[0].(map[string]interface{}); ok {
+					if a, ok := certattrs["cert"].(string); ok {
+						conn["serverCaCert"] = []byte(a)
+					}
+					if a, ok := certattrs["common_name"].(string); ok {
+						conn["commonName"] = []byte(a)
+					}
+					if a, ok := certattrs["create_time"].(string); ok {
+						conn["createTime"] = []byte(a)
+					}
+					if a, ok := certattrs["expiration_time"].(string); ok {
+						conn["expirationTime"] = []byte(a)
+					}
+					if a, ok := certattrs["sha1_fingerprint"].(string); ok {
+						conn["sha1Fingerprint"] = []byte(a)
 					}
 				}
-				return conn, nil
-			},
+			}
+			return conn, nil
 		}
 
 		r.UseAsync = true

--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -23,6 +23,49 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			}
 			return fmt.Sprintf("projects/%s/instances/%s", project, externalName), nil
 		}
+
+		// NOTE(@tnthornton) most of the connection details that were exported
+		// to the connection details secret are marked as non-sensitive for tf.
+		// We need to manually construct the secret details for those items.
+		r.Sensitive = config.Sensitive{
+			AdditionalConnectionDetailsFn: func(attr map[string]interface{}) (map[string][]byte, error) {
+				conn := map[string][]byte{}
+				if a, ok := attr["connection_name"].(string); ok {
+					conn["connectionName"] = []byte(a)
+				}
+				if a, ok := attr["private_ip_address"].(string); ok {
+					conn["privateIpAddress"] = []byte(a)
+				}
+				if a, ok := attr["public_ip_address"].(string); ok {
+					conn["publicIpAddress"] = []byte(a)
+				}
+				if a, ok := attr["root_password"].(string); ok {
+					conn["rootPassword"] = []byte(a)
+				}
+				// map
+				if certSlice, ok := attr["server_ca_cert"].([]interface{}); ok {
+					if certattrs, ok := certSlice[0].(map[string]interface{}); ok {
+						if a, ok := certattrs["cert"].(string); ok {
+							conn["cert"] = []byte(a)
+						}
+						if a, ok := certattrs["common_name"].(string); ok {
+							conn["commonName"] = []byte(a)
+						}
+						if a, ok := certattrs["create_time"].(string); ok {
+							conn["createTime"] = []byte(a)
+						}
+						if a, ok := certattrs["expiration_time"].(string); ok {
+							conn["expirationTime"] = []byte(a)
+						}
+						if a, ok := certattrs["sha1_fingerprint"].(string); ok {
+							conn["sha1Fingerprint"] = []byte(a)
+						}
+					}
+				}
+				return conn, nil
+			},
+		}
+
 		r.UseAsync = true
 	})
 	p.AddResourceConfigurator("google_sql_database", func(r *config.Resource) {

--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -6,7 +6,23 @@ import (
 
 	"github.com/crossplane/terrajet/pkg/config"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+
 	"github.com/crossplane-contrib/provider-jet-gcp/config/common"
+)
+
+// CloudSQL connection detail keys
+const (
+	CloudSQLSecretServerCACertificateCertKey            = "serverCACertificateCert"
+	CloudSQLSecretServerCACertificateCommonNameKey      = "serverCACertificateCommonName"
+	CloudSQLSecretServerCACertificateCreateTimeKey      = "serverCACertificateCreateTime"
+	CloudSQLSecretServerCACertificateExpirationTimeKey  = "serverCACertificateExpirationTime"
+	CloudSQLSecretServerCACertificateSha1FingerprintKey = "serverCACertificateSha1Fingerprint"
+
+	CloudSQLSecretConnectionName = "connectionName"
+
+	PrivateIPKey = "privateIP"
+	PublicIPKey  = "publicIP"
 )
 
 // Configure configures individual resources by adding custom
@@ -30,34 +46,34 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			conn := map[string][]byte{}
 			if a, ok := attr["connection_name"].(string); ok {
-				conn["connectionName"] = []byte(a)
+				conn[CloudSQLSecretConnectionName] = []byte(a)
 			}
 			if a, ok := attr["private_ip_address"].(string); ok {
-				conn["privateIpAddress"] = []byte(a)
+				conn[PrivateIPKey] = []byte(a)
 			}
 			if a, ok := attr["public_ip_address"].(string); ok {
-				conn["publicIpAddress"] = []byte(a)
+				conn[PublicIPKey] = []byte(a)
 			}
 			if a, ok := attr["root_password"].(string); ok {
-				conn["rootPassword"] = []byte(a)
+				conn[xpv1.ResourceCredentialsSecretPasswordKey] = []byte(a)
 			}
 			// map
 			if certSlice, ok := attr["server_ca_cert"].([]interface{}); ok {
 				if certattrs, ok := certSlice[0].(map[string]interface{}); ok {
 					if a, ok := certattrs["cert"].(string); ok {
-						conn["serverCaCert"] = []byte(a)
+						conn[CloudSQLSecretServerCACertificateCertKey] = []byte(a)
 					}
 					if a, ok := certattrs["common_name"].(string); ok {
-						conn["commonName"] = []byte(a)
+						conn[CloudSQLSecretServerCACertificateCommonNameKey] = []byte(a)
 					}
 					if a, ok := certattrs["create_time"].(string); ok {
-						conn["createTime"] = []byte(a)
+						conn[CloudSQLSecretServerCACertificateCreateTimeKey] = []byte(a)
 					}
 					if a, ok := certattrs["expiration_time"].(string); ok {
-						conn["expirationTime"] = []byte(a)
+						conn[CloudSQLSecretServerCACertificateExpirationTimeKey] = []byte(a)
 					}
 					if a, ok := certattrs["sha1_fingerprint"].(string); ok {
-						conn["sha1Fingerprint"] = []byte(a)
+						conn[CloudSQLSecretServerCACertificateSha1FingerprintKey] = []byte(a)
 					}
 				}
 			}


### PR DESCRIPTION
### Description of your changes
Prior to this change, the connection details secret from `google_sql_database_instance` included no exported attributes as seen in #47.

For this change the ResourceConfigurator for `google_sql_database_instance` was extended to include transferring details from the exported attributes to the connection details secret that is inline with behavior we see in provider-gcp.

Fixes #47 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
1. `kubectl apply -f examples/sql/instance.yaml`
2. Verified that the connection details secret included the updated information:
```bash
$ kubectl -n crossplane-system get secrets example-sql-db-instance-secret -o yaml
apiVersion: v1
data:
  cert: <REDACTED>
  commonName: <REDACTED>
  connectionName: <REDACTED>
  createTime: MjAyMi0wMy0wOVQwMjowOToyMi40Njla
  expirationTime: MjAzMi0wMy0wNlQwMjoxMDoyMi40Njla
  privateIpAddress: ""
  publicIpAddress: <REDACTED>
  sha1Fingerprint: <REDACTED>
kind: Secret
metadata:
  creationTimestamp: "2022-03-09T02:09:12Z"
  name: example-sql-db-instance-secret
  namespace: crossplane-system
  ownerReferences:
  - apiVersion: sql.gcp.jet.crossplane.io/v1alpha2
    controller: true
    kind: DatabaseInstance
    name: example-instance-002
    uid: 9a916bb7-68c9-41a9-9ac2-2fbb4063c104
  resourceVersion: "1744834"
  uid: 05ab12b7-0e3a-4956-8f1a-06b4b01a7182
type: connection.crossplane.io/v1alpha1
```
