### PR TITLE
User resources: add the username to the connection details secret output

### DIFF
--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -21,6 +21,8 @@ const (
 
 	CloudSQLSecretConnectionName = "connectionName"
 
+	CloudSQLUserName = "userName"
+
 	PrivateIPKey = "privateIP"
 	PublicIPKey  = "publicIP"
 )
@@ -147,6 +149,16 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 
 		r.References["instance"] = config.Reference{
 			Type: "DatabaseInstance",
+		}
+
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			// reference: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user#argument-reference
+			// map the Terraform attribute name to the Provider's connection details attribute name
+			if a, ok := attr["name"].(string); ok {
+				conn[CloudSQLUserName] = []byte(a)
+			}
+			return conn, nil
 		}
 
 		r.UseAsync = true

--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -21,7 +21,7 @@ const (
 
 	CloudSQLSecretConnectionName = "connectionName"
 
-	CloudSQLUserName = "userName"
+	CloudSQLUserName = "username"
 
 	PrivateIPKey = "privateIP"
 	PublicIPKey  = "publicIP"

--- a/examples/sql/user.yaml
+++ b/examples/sql/user.yaml
@@ -18,3 +18,6 @@ spec:
       key: password
     instanceRef:
       name: example-instance
+  writeConnectionSecretToRef:
+    name: example-sql-user-secret
+    namespace: crossplane-system


### PR DESCRIPTION
Signed-off-by: Jamal Maduro <jamal@upbound.io>

### Description of your changes
Adds a `userName` field to the connection details for `User` custom resource definition secrets.

Fixes #62 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

#### Provisioning
##### Clone Repo
Using SSH
`git clone git@github.com:crossplane-contrib/provider-jet-gcp.git`
OR
Using HTTPS
`git clone https://github.com/crossplane-contrib/provider-jet-gcp.git`
##### Enter Repo
`cd provider-jet-gcp`
##### Build provider
```
# CLEAN
# Reference: 
make clean

sudo rm -rf package/crds
sudo find . -iname 'zz_*' -delete
sudo find . -type d -empty -delete
sudo find internal/controller -iname 'zz_*' -delete
sudo find internal/controller -type d -empty -delete

kind delete cluster

# CREATE CLUSTER and INSTALL crossplane
# Reference: https://crossplane.io/docs/v1.7/getting-started/install-configure.html
kind create cluster --image kindest/node:v1.23.0 --wait 5m
kubectl create namespace crossplane-system

helm repo add crossplane-stable https://charts.crossplane.io/stable
helm repo update
helm install crossplane --namespace crossplane-system crossplane-stable/crossplane

# Check Crossplane Status
helm list -n crossplane-system
kubectl get all -n crossplane-system

# Create generic kubernetes secret for the provider
kubectl create secret generic example-creds -n crossplane-system --from-file=creds=${HOME}/creds.json

# GENERATE resource definitions
make generate
kubectl apply -f package/crds

# APPLY Examples
kubectl apply -f examples/providerconfig/providerconfig.yaml
kubectl apply -f examples/sql/instance.yaml
kubectl apply -f examples/sql/database.yaml
kubectl apply -f examples/sql/user.yaml

# RUN provider locally
make run &
```

#### Verification

<img width="1508" alt="provider jet gcp fix validation screenshot 2022-06-09 at 12 57 20 PM" src="https://user-images.githubusercontent.com/105229510/172935217-cb71256f-db53-409d-a27d-1a00a6fb1a3d.png">

[contribution process]: https://git.io/fj2m9
