### PR TITLE
GCP SQL User IDs are reversed from other GCP IDs

### DIFF
--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -2,7 +2,9 @@ package sql
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/crossplane/terrajet/pkg/config"
 
@@ -74,18 +76,25 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("google_sql_user", func(r *config.Resource) {
 		r.Version = common.VersionV1alpha2
 		r.ExternalName = config.NameAsIdentifier
-		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
-		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
-			project, err := common.GetField(providerConfig, common.KeyProject)
-			if err != nil {
-				return "", err
+		r.ExternalName.GetExternalNameFn = func(tfstate map[string]interface{}) (string, error) {
+			id, ok := tfstate["id"].(string)
+			if !ok {
+				return "", errors.New("cannot get the id field as string in tfstate")
 			}
+			words := strings.Split(id, "/")
+			return words[0], nil
+		}
+		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			instance, err := common.GetField(parameters, "instance")
 			if err != nil {
 				return "", err
 			}
+			host, err := common.GetField(parameters, "host")
+			if err != nil {
+				host = ""
+			}
 
-			return fmt.Sprintf("%s/%s/%s", project, instance, externalName), nil
+			return fmt.Sprintf("%s/%s/%s", externalName, host, instance), nil
 		}
 
 		r.References["instance"] = config.Reference{


### PR DESCRIPTION
### Description of your changes

Resolves a situation where the "id" field of User resources for Cloud SQL are returned in the opposite order from other GCP resources.

Fixes #59 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Launched Mysql and Postgres database using this provider into gcp.

Tests included mysql users that bot did and did not include a `host` parameter.

All tests passed.

[contribution process]: https://git.io/fj2m9
