### PR TITLE
Add https:// to server endpoint in kubeconfig

### DIFF
--- a/config/container/config.go
+++ b/config/container/config.go
@@ -45,6 +45,7 @@ func Configure(p *config.Provider) {
 			if err != nil {
 				return nil, err
 			}
+			server = "https://" + server
 			caData, err := common.GetField(attr, "master_auth[0].cluster_ca_certificate")
 			if err != nil {
 				return nil, err


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The lack of https:// made kubectl (and maybe more?) attempt to hit port 80, resulting in a timeout.

This is also more consitent with provider-gcp which returns the endpoint with https
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #69

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran it locally, verified that https is now present

[contribution process]: https://git.io/fj2m9
