### PR TITLE
Add network and subnetwork references to `Cluster`

### DIFF
--- a/apis/container/v1alpha2/zz_cluster_types.go
+++ b/apis/container/v1alpha2/zz_cluster_types.go
@@ -294,12 +294,20 @@ type ClusterParameters struct {
 	MonitoringService *string `json:"monitoringService,omitempty" tf:"monitoring_service,omitempty"`
 
 	// The name or self_link of the Google Compute Engine network to which the cluster is connected. For Shared VPC, set this to the self link of the shared network.
+	// +crossplane:generate:reference:type=Network
+	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-jet-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Network *string `json:"network,omitempty" tf:"network,omitempty"`
 
 	// Configuration options for the NetworkPolicy feature.
 	// +kubebuilder:validation:Optional
 	NetworkPolicy []NetworkPolicyParameters `json:"networkPolicy,omitempty" tf:"network_policy,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	NetworkRef *v1.Reference `json:"networkRef,omitempty" tf:"-"`
+
+	// +kubebuilder:validation:Optional
+	NetworkSelector *v1.Selector `json:"networkSelector,omitempty" tf:"-"`
 
 	// Determines whether alias IPs or routes will be used for pod IPs in the cluster.
 	// +kubebuilder:validation:Optional
@@ -350,8 +358,16 @@ type ClusterParameters struct {
 	ResourceUsageExportConfig []ResourceUsageExportConfigParameters `json:"resourceUsageExportConfig,omitempty" tf:"resource_usage_export_config,omitempty"`
 
 	// The name or self_link of the Google Compute Engine subnetwork in which the cluster's instances are launched.
+	// +crossplane:generate:reference:type=Subnetwork
+	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-jet-gcp/config/common.SelfLinkExtractor()
 	// +kubebuilder:validation:Optional
 	Subnetwork *string `json:"subnetwork,omitempty" tf:"subnetwork,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	SubnetworkRef *v1.Reference `json:"subnetworkRef,omitempty" tf:"-"`
+
+	// +kubebuilder:validation:Optional
+	SubnetworkSelector *v1.Selector `json:"subnetworkSelector,omitempty" tf:"-"`
 
 	// Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it.
 	// +kubebuilder:validation:Optional

--- a/apis/container/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/container/v1alpha2/zz_generated.deepcopy.go
@@ -716,6 +716,16 @@ func (in *ClusterParameters) DeepCopyInto(out *ClusterParameters) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.NetworkRef != nil {
+		in, out := &in.NetworkRef, &out.NetworkRef
+		*out = new(v1.Reference)
+		**out = **in
+	}
+	if in.NetworkSelector != nil {
+		in, out := &in.NetworkSelector, &out.NetworkSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.NetworkingMode != nil {
 		in, out := &in.NetworkingMode, &out.NetworkingMode
 		*out = new(string)
@@ -806,6 +816,16 @@ func (in *ClusterParameters) DeepCopyInto(out *ClusterParameters) {
 		in, out := &in.Subnetwork, &out.Subnetwork
 		*out = new(string)
 		**out = **in
+	}
+	if in.SubnetworkRef != nil {
+		in, out := &in.SubnetworkRef, &out.SubnetworkRef
+		*out = new(v1.Reference)
+		**out = **in
+	}
+	if in.SubnetworkSelector != nil {
+		in, out := &in.SubnetworkSelector, &out.SubnetworkSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.VerticalPodAutoscaling != nil {
 		in, out := &in.VerticalPodAutoscaling, &out.VerticalPodAutoscaling

--- a/apis/container/v1alpha2/zz_generated.resolvers.go
+++ b/apis/container/v1alpha2/zz_generated.resolvers.go
@@ -25,6 +25,48 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ResolveReferences of this Cluster.
+func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error {
+	r := reference.NewAPIResolver(c, mg)
+
+	var rsp reference.ResolutionResponse
+	var err error
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Network),
+		Extract:      common.SelfLinkExtractor(),
+		Reference:    mg.Spec.ForProvider.NetworkRef,
+		Selector:     mg.Spec.ForProvider.NetworkSelector,
+		To: reference.To{
+			List:    &NetworkList{},
+			Managed: &Network{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.Network")
+	}
+	mg.Spec.ForProvider.Network = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.NetworkRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Subnetwork),
+		Extract:      common.SelfLinkExtractor(),
+		Reference:    mg.Spec.ForProvider.SubnetworkRef,
+		Selector:     mg.Spec.ForProvider.SubnetworkSelector,
+		To: reference.To{
+			List:    &SubnetworkList{},
+			Managed: &Subnetwork{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.Subnetwork")
+	}
+	mg.Spec.ForProvider.Subnetwork = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.SubnetworkRef = rsp.ResolvedReference
+
+	return nil
+}
+
 // ResolveReferences of this NodePool.
 func (mg *NodePool) ResolveReferences(ctx context.Context, c client.Reader) error {
 	r := reference.NewAPIResolver(c, mg)

--- a/config/container/config.go
+++ b/config/container/config.go
@@ -36,6 +36,14 @@ func Configure(p *config.Provider) {
 			}
 			return fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, externalName), nil
 		}
+		r.References["network"] = config.Reference{
+			Type:      "Network",
+			Extractor: common.PathSelfLinkExtractor,
+		}
+		r.References["subnetwork"] = config.Reference{
+			Type:      "Subnetwork",
+			Extractor: common.PathSelfLinkExtractor,
+		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			name, err := common.GetField(attr, "name")
 			if err != nil {

--- a/package/crds/container.gcp.jet.crossplane.io_clusters.yaml
+++ b/package/crds/container.gcp.jet.crossplane.io_clusters.yaml
@@ -556,6 +556,29 @@ spec:
                       - enabled
                       type: object
                     type: array
+                  networkRef:
+                    description: A Reference to a named object.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  networkSelector:
+                    description: A Selector selects an object.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                    type: object
                   networkingMode:
                     description: Determines whether alias IPs or routes will be used
                       for pod IPs in the cluster.
@@ -1122,6 +1145,29 @@ spec:
                     description: The name or self_link of the Google Compute Engine
                       subnetwork in which the cluster's instances are launched.
                     type: string
+                  subnetworkRef:
+                    description: A Reference to a named object.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  subnetworkSelector:
+                    description: A Selector selects an object.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                    type: object
                   verticalPodAutoscaling:
                     description: Vertical Pod Autoscaling automatically adjusts the
                       resources of pods controlled by it.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #75

Adds references for `Network` and `Subnetwork` resources to the `Cluster` resource.

`crossplane-contrib/provider-gcp`[^1] supports both but this provider doesn't support regardless of its support for other resources like the `Router` resource, which makes users use `selfLink` properties.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

[^1]: e.g.) https://github.com/crossplane-contrib/provider-gcp/blob/v0.21.0/apis/container/v1beta2/cluster_types.go#L248
