### PR TITLE
fix LeaderElectionID typo

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -80,7 +80,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-jet-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-jet-gcp",
 		SyncPeriod:                 syncPeriod,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),


### PR DESCRIPTION
Signed-off-by: Yann Toqué <toqueyann@gmail.com>

### Description of your changes

There is a typo introduced in this file `provider-jet-gcp/cmd/provider/main.go` at [this line](https://github.com/crossplane-contrib/provider-jet-gcp/blob/40c122feead81ae5e932ff91edb6da2c9e9e4634/cmd/provider/main.go#L83) : 
https://github.com/crossplane-contrib/provider-jet-gcp/blob/40c122feead81ae5e932ff91edb6da2c9e9e4634/cmd/provider/main.go#L83

Fixes #

change aws by gcp.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

The code changes the LeaderElectionID from `crossplane-leader-election-provider-jet-aws` to the more appropriate `crossplane-leader-election-provider-jet-gcp`. 